### PR TITLE
fix gh release binaries --version always returning 0.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,6 +155,7 @@ jobs:
       - uses: wangyoucao577/go-release-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          build_command: make
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: ${{ env.GOVERSION }}


### PR DESCRIPTION
Resovles:

    $ ./expfake --version
    0.0.0